### PR TITLE
Unwrap structured field payloads before value conversion

### DIFF
--- a/pypentair/utils.py
+++ b/pypentair/utils.py
@@ -306,7 +306,7 @@ API_FIELD_VALUE_FUNCTION: Final[dict[str, Callable]] = {
 
 
 def get_api_field_name_and_value(
-    key: str, value: str | int | float | datetime
+    key: str, value: str | int | float | datetime | Mapping[str, Any]
 ) -> tuple[str, Any]:
     """Get the API field name and converted value."""
     name = API_FIELD_NAME_MAP.get(key, key)

--- a/pypentair/utils.py
+++ b/pypentair/utils.py
@@ -310,6 +310,8 @@ def get_api_field_name_and_value(
 ) -> tuple[str, Any]:
     """Get the API field name and converted value."""
     name = API_FIELD_NAME_MAP.get(key, key)
+    if isinstance(value, Mapping) and "value" in value:
+        value = value["value"]
     val = value
     if _fn := API_FIELD_VALUE_FUNCTION.get(key):
         try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,10 +57,11 @@ def test_field_mapping_error(caplog: pytest.LogCaptureFixture) -> None:
         ("s18", "Current power", 221),
         ("s19", "Current motor speed", 50.0),
         ("s26", "Current estimated flow", 27.0),
+        ("s2", "Finished good serial number", "serial"),
     ],
 )
 def test_field_mapping_structured_payload(
-    key: str, name: str, value: str | float | datetime
+    key: str, name: str, value: str | int | float | datetime
 ) -> None:
     """Test field mapping with the newer structured (dict-wrapped) payload."""
     raw_values = {
@@ -70,6 +71,7 @@ def test_field_mapping_structured_payload(
         "s18": "221",
         "s19": "500",
         "s26": "270",
+        "s2": "serial",
     }
     wrapped = {
         "name": "whatever",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,3 +46,43 @@ def test_field_mapping_error(caplog: pytest.LogCaptureFixture) -> None:
         "Could not convert key 's1 (Device time)' value '00': time data '00' does not match format '%y%m%d%H%M%S'"
         in caplog.messages
     )
+
+
+@pytest.mark.parametrize(
+    "key,name,value",
+    [
+        ("s1", "Device time", datetime(2026, 6, 8, 8, 26, 0)),
+        ("s13", "RSSI", -74),
+        ("s17", "Current pressure", 74.4),
+        ("s18", "Current power", 221),
+        ("s19", "Current motor speed", 50.0),
+        ("s26", "Current estimated flow", 27.0),
+    ],
+)
+def test_field_mapping_structured_payload(
+    key: str, name: str, value: str | float | datetime
+) -> None:
+    """Test field mapping with the newer structured (dict-wrapped) payload."""
+    raw_values = {
+        "s1": "260608082600",
+        "s13": "-74",
+        "s17": "744",
+        "s18": "221",
+        "s19": "500",
+        "s26": "270",
+    }
+    wrapped = {
+        "name": "whatever",
+        "min": "NA",
+        "max": "NA",
+        "unit": "unit",
+        "type": "STR",
+        "category": "status",
+        "cloud": False,
+        "visible": True,
+        "home": False,
+        "value": raw_values[key],
+        "timestamp": "1780921579",
+        "delivered": "1780921580034",
+    }
+    assert get_api_field_name_and_value(key, wrapped) == (name, value)


### PR DESCRIPTION
Fixes #111

The Pentair API recently changed the fields schema from flat primitive values to metadata dicts containing a value key. 

This caused strptime()/int()/float() TypeErrors in get_api_field_name_and_value for every converted field (device time, RSSI, pressure, power, speed, flow), and left raw dicts exposed for non-converted fields.

This unwraps value["value"] when the input is a Mapping, before conversion — backward compatible with the old flat format. Added parametrized tests covering the new payload shape captured in #111.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of structured sensor data so values are correctly extracted and converted before being sent to the API.
  * Preserved existing field mapping, type conversion, and error handling behavior.

* **Tests**
  * Added coverage for structured payloads across time, numeric, pressure, flow, and motor speed sensor values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->